### PR TITLE
Add `beforeParse` and `reviver` options

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,14 @@ const stripBom = require('strip-bom');
 const parseJson = require('parse-json');
 const pify = require('pify');
 
-const parse = (data, fp) => parseJson(stripBom(data), path.relative('.', fp));
+const parse = (data, fp, options) => {
+	options = options || {};
+	data = stripBom(data);
+	if (typeof options.beforeParse === 'function') {
+		data = options.beforeParse(data);
+	}
+	return parseJson(data, options.reviver, path.relative('.', fp));
+};
 
-module.exports = fp => pify(fs.readFile)(fp, 'utf8').then(data => parse(data, fp));
-module.exports.sync = fp => parse(fs.readFileSync(fp, 'utf8'), fp);
+module.exports = (fp, options) => pify(fs.readFile)(fp, 'utf8').then(data => parse(data, fp, options));
+module.exports.sync = (fp, options) => parse(fs.readFileSync(fp, 'utf8'), fp, options);

--- a/readme.md
+++ b/readme.md
@@ -26,13 +26,29 @@ loadJsonFile('foo.json').then(json => {
 
 ## API
 
-### loadJsonFile(filepath)
+### loadJsonFile(filepath, [options])
 
 Returns a promise for the parsed JSON.
 
-### loadJsonFile.sync(filepath)
+### loadJsonFile.sync(filepath, [options])
 
 Returns the parsed JSON.
+
+#### options
+
+Type: `Object`
+
+##### beforeParse
+
+Type: `Function`
+
+Applies a function to the JSON string before parsing.
+
+##### reviver
+
+Type: `Function`
+
+Prescribes how the value originally produced by parsing is transformed, before being returned. See [`JSON.parse` docs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse#Using_the_reviver_parameter) for more.
 
 
 ## Related

--- a/test.js
+++ b/test.js
@@ -1,6 +1,6 @@
 import path from 'path';
 import test from 'ava';
-import m from './';
+import m from '.';
 
 const fixture = path.join(__dirname, 'package.json');
 
@@ -11,4 +11,14 @@ test('async', async t => {
 
 test('sync', t => {
 	t.is(m.sync(fixture).name, 'load-json-file');
+});
+
+test('beforeParse', async t => {
+	const data = await m(fixture, {beforeParse: s => s.replace('"name": "load-json-file"', '"name": "foo"')});
+	t.is(data.name, 'foo');
+});
+
+test('reviver', async t => {
+	const data = await m(fixture, {reviver: (k, v) => k === 'name' ? 'foo' : v});
+	t.is(data.name, 'foo');
 });


### PR DESCRIPTION
This adds `options` parameter with
* `reviver` from `parse-json` / `JSON.parse`
* arbitrary functions `before` and `after` for initial string and final value
* `prefix` for arbitrary prefixes (like the XSSI prevention prefix or a `var=` prefix).