### PR TITLE
Remove link to `strip-bom`

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 > Read and parse a JSON file
 
-It also [strips UTF-8 BOM](https://github.com/sindresorhus/strip-bom).
+It also strips UTF-8 [byte order mark](https://en.wikipedia.org/wiki/Byte_order_mark#UTF-8) (BOM).
 
 ## Install
 


### PR DESCRIPTION
Copied from [`strip-bom`](https://github.com/sindresorhus/strip-bom/blob/main/readme.md).